### PR TITLE
feature: Added Service account in UI

### DIFF
--- a/src/components/ui/single-search-selector.tsx
+++ b/src/components/ui/single-search-selector.tsx
@@ -1,0 +1,173 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Check, ChevronsUpDown, X, Search } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+interface SingleSearchSelectorProps {
+  options: Array<{ value: string; label: string }>;
+  value?: string;
+  onSelect: (value: string) => void;  // Changed from onChange to onSelect
+  loadOptions?: (search: string) => void;  // Added for dynamic loading
+  title?: string;  // Added title prop (used as placeholder)
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+const SingleSearchSelector: React.FC<SingleSearchSelectorProps> = ({
+  options = [],
+  value,
+  onSelect,  // Changed from onChange
+  loadOptions,  // Added
+  title,  // Added - will be used as placeholder
+  placeholder,
+  searchPlaceholder = "Search...",
+  emptyMessage = "No results found.",
+  disabled = false,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selectedOption = options.find(option => option.value === value);
+  
+  // Use title as placeholder if provided
+  const displayPlaceholder = title || placeholder || "Select an option...";
+
+  const filteredOptions = options.filter(option =>
+    option.label.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+      // Focus the search input when dropdown opens
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open]);
+
+  // Call loadOptions when search query changes (if provided)
+  useEffect(() => {
+    if (loadOptions && searchQuery) {
+      const timeoutId = setTimeout(() => {
+        loadOptions(searchQuery);
+      }, 300); // Debounce search
+      
+      return () => clearTimeout(timeoutId);
+    }
+  }, [searchQuery, loadOptions]);
+
+  const handleSelect = (selectedValue: string) => {
+    onSelect(selectedValue);  // Always call onSelect with the value
+    setOpen(false);
+    setSearchQuery('');
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onSelect('');  // Pass empty string to clear
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className={cn("relative w-full", className)} ref={containerRef}>
+      <Button
+        type="button"
+        variant="outline"
+        role="combobox"
+        aria-expanded={open}
+        disabled={disabled}
+        onClick={() => setOpen(!open)}
+        className={cn(
+          "w-full justify-between",
+          !value && "text-muted-foreground"
+        )}
+      >
+        <span className="truncate">
+          {selectedOption ? selectedOption.label : displayPlaceholder}
+        </span>
+        <div className="flex items-center gap-1">
+          {value && !disabled && (
+            <X
+              className="h-4 w-4 opacity-50 hover:opacity-100 transition-opacity"
+              onClick={handleClear}
+            />
+          )}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </div>
+      </Button>
+
+      {open && (
+        <div 
+          className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md"
+          onKeyDown={handleKeyDown}
+        >
+          {/* Search Input */}
+          <div className="flex items-center border-b px-3">
+            <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+            <input
+              ref={inputRef}
+              type="text"
+              className="flex h-10 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder={searchPlaceholder}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+
+          {/* Options List */}
+          <div className="max-h-64 overflow-auto py-1">
+            {filteredOptions.length === 0 ? (
+              <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                {emptyMessage}
+              </div>
+            ) : (
+              filteredOptions.map((option) => (
+                <div
+                  key={option.value}
+                  className={cn(
+                    "relative flex cursor-pointer select-none items-center px-3 py-2 text-sm outline-none transition-colors",
+                    "hover:bg-accent hover:text-accent-foreground",
+                    value === option.value && "bg-accent text-accent-foreground"
+                  )}
+                  onClick={() => handleSelect(option.value)}
+                  role="option"
+                  aria-selected={value === option.value}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === option.value ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  <span className="truncate">{option.label}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SingleSearchSelector;

--- a/src/hooks/authproviders/index.ts
+++ b/src/hooks/authproviders/index.ts
@@ -12,6 +12,8 @@ export interface Params {
     is_secret: boolean
 }
 
+export const AuthProviderTypeGoIAMClient = "GOIAM/CLIENT";
+
 export interface AuthProvider {
     id: string
     name: string
@@ -38,14 +40,22 @@ interface AuthProviderResponse {
     data: AuthProvider
 }
 
+interface EnableServiceAccountResponse {
+    success: boolean
+    message: string
+    data: any
+}
+
 interface AuthProvidersState {
     authproviders: AuthProvider[]
     loadingAuthProviders: boolean
     updatingAuthProvider: boolean
     creatingAuthProvider: boolean
+    enablingServiceAccount: boolean
     err: string
     createdAuthProvider: boolean
     updatedAuthProvider: boolean
+    enabledServiceAccount: boolean
 }
 
 const state = hookstate<AuthProvidersState>({
@@ -53,8 +63,10 @@ const state = hookstate<AuthProvidersState>({
     loadingAuthProviders: false,
     updatingAuthProvider: false,
     creatingAuthProvider: false,
+    enablingServiceAccount: false,
     createdAuthProvider: false,
     updatedAuthProvider: false,
+    enabledServiceAccount: false,
     err: "",
 })
 
@@ -88,9 +100,9 @@ const wrapState = (state: State<AuthProvidersState>, project: ProjectWrapState, 
                 throw new Error(`Failed to fetch auth providers: ${error.message}`);
             });
         toast.promise(loadingResolve, {
-            loading: "Loading projects...",
-            success: "Projects loaded successfully",
-            error: err => err.message || "Failed to load projects",
+            loading: "Loading auth providers...",
+            success: "Auth providers loaded successfully",
+            error: err => err.message || "Failed to load auth providers",
         });
     },
     createAuthProvider: (authProvider: AuthProvider) => {
@@ -171,6 +183,47 @@ const wrapState = (state: State<AuthProvidersState>, project: ProjectWrapState, 
             error: err => err.message || "Failed to update auth provider",
         });
     },
+    enableServiceAccount: () => {
+        if (state.enablingServiceAccount.value) {
+            console.debug("Already enabling service account, ignoring new request");
+            return;
+        }
+        state.enablingServiceAccount.set(true);
+        const url = `${API_SERVER}/authprovider/v1/enable-service-account`;
+        //normal fetch
+        const loadingResolve = auth.fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-Project-Ids": project.project?.id || "",
+            },
+            body: JSON.stringify({
+                project_id: project.project?.id || ""
+            }),
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+                return response.json();
+            })
+            .then((data: EnableServiceAccountResponse) => {
+                if (!data.success) {
+                    throw new Error(data.message || "Failed to enable service account");
+                }
+                state.enabledServiceAccount.set(true);
+                state.enablingServiceAccount.set(false);
+            })
+            .catch((error) => {
+                state.enablingServiceAccount.set(false);
+                throw new Error(`Failed to enable service account: ${error.message}`);
+            });
+        toast.promise(loadingResolve, {
+            loading: "Enabling service account...",
+            success: "Service account enabled successfully",
+            error: err => err.message || "Failed to enable service account",
+        });
+    },
     resetError: () => {
         state.err.set("");
     },
@@ -180,17 +233,23 @@ const wrapState = (state: State<AuthProvidersState>, project: ProjectWrapState, 
     resetUpdatedAuthProvider: () => {
         state.updatedAuthProvider.set(false);
     },
+    resetEnabledServiceAccount: () => {
+        state.enabledServiceAccount.set(false);
+    },
     updatedAuthProvider: state.updatedAuthProvider.value,
     createdAuthProvider: state.createdAuthProvider.value,
+    enabledServiceAccount: state.enabledServiceAccount.value,
     loadingAuthProviders: state.loadingAuthProviders.value,
     updatingAuthProvider: state.updatingAuthProvider.value,
     creatingAuthProvider: state.creatingAuthProvider.value,
+    enablingServiceAccount: state.enablingServiceAccount.value,
     err: state.err.value,
     authproviders: state.authproviders.value,
     authprovidersMap: state.authproviders.value.reduce<{ [key: string]: ImmutableObject<AuthProvider> }>((acc, authProvider) => {
         acc[authProvider.id] = authProvider;
         return acc;
     }, {}),
+    hasServiceAccount: state.authproviders.value.some(provider => provider.provider === AuthProviderTypeGoIAMClient),
 })
 
 

--- a/src/hooks/clients/index.ts
+++ b/src/hooks/clients/index.ts
@@ -15,6 +15,8 @@ export interface Client {
     default_auth_provider_id: string
     go_iam_client: boolean
     enabled: boolean
+    linked_user_id?: string
+    linked_user_email?: string 
     created_at: string
     created_by: string
     updated_at: string

--- a/src/pages/authprovider/EnableServiceAccount.tsx
+++ b/src/pages/authprovider/EnableServiceAccount.tsx
@@ -1,0 +1,87 @@
+import { Key, Loader2Icon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog"
+import { useEffect, useState } from "react"
+import { useAuthProviderState, AuthProviderTypeGoIAMClient } from "@/hooks/authproviders"
+
+const EnableServiceAccount = () => {
+    const authProviderState = useAuthProviderState();
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    const handleEnable = () => {
+        authProviderState.enableServiceAccount();
+    };
+
+    useEffect(() => {
+        if (authProviderState.enabledServiceAccount) {
+            setDialogOpen(false);
+            authProviderState.resetEnabledServiceAccount();
+            // Refresh auth providers to show the new GOIAM/CLIENT provider
+            authProviderState.fetchAuthProviders();
+        }
+    }, [authProviderState.enabledServiceAccount]);
+
+    // Check if service account is already enabled
+    if (authProviderState.hasServiceAccount) {
+        return (
+            <Button disabled variant="outline">
+                <Key className="mr-2 h-4 w-4" />
+                Service Account Enabled
+            </Button>
+        );
+    }
+
+    return (
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+                <Button variant="outline">
+                    <Key className="mr-2 h-4 w-4" />
+                    Enable Service Account
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>Enable Service Account</DialogTitle>
+                    <DialogDescription>
+                        This will enable GOIAM/CLIENT authentication provider for service accounts in your project.
+                        Service accounts allow programmatic access to your application without user interaction.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4">
+                    <p className="text-sm text-muted-foreground">
+                        Are you sure you want to enable service account support (GOIAM/CLIENT) for this project?
+                    </p>
+                </div>
+                <DialogFooter>
+                    <Button 
+                        variant="outline" 
+                        onClick={() => setDialogOpen(false)} 
+                        disabled={authProviderState.enablingServiceAccount}
+                    >
+                        Cancel
+                    </Button>
+                    <Button 
+                        onClick={handleEnable} 
+                        disabled={authProviderState.enablingServiceAccount}
+                    >
+                        {authProviderState.enablingServiceAccount ? (
+                            <><Loader2Icon className="animate-spin mr-2" /> Enabling...</>
+                        ) : (
+                            "Yes, Enable"
+                        )}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default EnableServiceAccount;

--- a/src/pages/authprovider/index.tsx
+++ b/src/pages/authprovider/index.tsx
@@ -13,8 +13,11 @@ import { format } from "@formkit/tempo"
 import { useNavState } from "@/hooks/nav"
 import AddProject from "./AddAuthProvider"
 import UpdateProject from "./UpdateAuthProvider"
+import EnableServiceAccount from "./EnableServiceAccount"
 import { useAuthProviderState } from "@/hooks/authproviders"
 import { Badge } from "@/components/ui/badge"
+import {AuthProviderTypeGoIAMClient} from "@/hooks/authproviders"
+
 
 const AuthProvidersListPage = () => {
     const navState = useNavState()
@@ -30,8 +33,8 @@ const AuthProvidersListPage = () => {
 
     return (
         <div className="w-full">
-            <div className="flex items-center justify-end py-4">
-
+            <div className="flex items-center justify-end py-4 gap-2">
+                <EnableServiceAccount />
                 <AddProject />
             </div>
             <div className="rounded-md border">
@@ -51,7 +54,9 @@ const AuthProvidersListPage = () => {
                                 <TableCell><Badge>{authProvider.provider}</Badge></TableCell>
                                 <TableCell>{format(new Date(authProvider.updated_at || authProvider.created_at))}</TableCell>
                                 <TableCell>
-                                    <UpdateProject data={JSON.parse(JSON.stringify(authProvider))} />
+                                    {authProvider.provider !== AuthProviderTypeGoIAMClient && (
+                                        <UpdateProject data={JSON.parse(JSON.stringify(authProvider))} />
+                                    )}
                                 </TableCell>
                             </TableRow>
                         ))}

--- a/src/pages/client/index.tsx
+++ b/src/pages/client/index.tsx
@@ -19,6 +19,7 @@ import { useClientState } from "@/hooks/clients"
 import { useAuthProviderState } from "@/hooks/authproviders"
 import { Button } from "@/components/ui/button"
 import { Check, Copy } from "lucide-react"
+import {AuthProviderTypeGoIAMClient} from "@/hooks/authproviders"
 
 const ClientsListPage = () => {
     const navState = useNavState()
@@ -111,7 +112,9 @@ const ClientsListPage = () => {
                                 </TableCell>
                                 <TableCell>{format(new Date(client.updated_at || client.created_at))}</TableCell>
                                 <TableCell>
-                                    <UpdateProject data={JSON.parse(JSON.stringify(client))} />
+                                    {authProvidersState.authprovidersMap[client.default_auth_provider_id]?.name !== AuthProviderTypeGoIAMClient && (
+                                        <UpdateProject data={JSON.parse(JSON.stringify(client))} />
+                                    )}
                                 </TableCell>
                             </TableRow>
                         ))}


### PR DESCRIPTION
I have added UI support for enabling GOIAM/CLIENT as auth provider. And using it

### Workflow (UI)

- first created a enable button in auth providers → it will enable the service account support in a project
- Once enable now user can create a client using GOIAM/CLIENT auth provider
- Once user choose GOIAM/CLIENT as his auth provider he has to give linked user email
- From email i have coverted user Id in backend
- Once done you client is configured.
- Now user can use GOIAM/Client using  clientId and clientSecert .

